### PR TITLE
feat: 정산 내역 조회 API (ALBA-16)

### DIFF
--- a/src/DTO/settlement_history_dto.ts
+++ b/src/DTO/settlement_history_dto.ts
@@ -1,0 +1,45 @@
+/**
+ * 정산 내역 DTO
+ */
+
+/**
+ * 정산 내역 항목
+ */
+export interface SettlementHistoryItemDto {
+  /** 정산 ID */
+  incomeLogId: string;
+  /** 근무 날짜 */
+  workDate: string;
+  /** 업체명 */
+  storeName: string;
+  /** 정산 금액 */
+  amount: number;
+  /** 정산 날짜 */
+  incomeDate: string;
+}
+
+/**
+ * 정산 내역 조회 응답
+ */
+export interface SettlementHistoryResponseDto {
+  /** 정산 내역 목록 */
+  settlements: SettlementHistoryItemDto[];
+  /** 총 정산 금액 */
+  totalAmount: number;
+  /** 조회 기간 시작 */
+  periodStart: string;
+  /** 조회 기간 종료 */
+  periodEnd: string;
+}
+
+/**
+ * 월별 정산 요약
+ */
+export interface MonthlySettlementSummaryDto {
+  /** 년월 (YYYY-MM) */
+  month: string;
+  /** 총 정산 금액 */
+  totalAmount: number;
+  /** 정산 건수 */
+  count: number;
+}

--- a/src/controller/settlement_history_controller.ts
+++ b/src/controller/settlement_history_controller.ts
@@ -1,0 +1,79 @@
+import { Controller, Get, Route, Tags, Path, Query, SuccessResponse, Response } from 'tsoa';
+import SettlementHistoryService from '../service/settlement_history_service';
+import {
+  SettlementHistoryResponseDto,
+  MonthlySettlementSummaryDto,
+} from '../DTO/settlement_history_dto';
+import { TsoaSuccessResponse } from '../config/response_interface';
+import { uuidToBuffer } from '../util/uuid_util';
+
+/**
+ * Settlement History Controller
+ * 정산 내역 조회 API
+ */
+@Route('api/settlement-history')
+@Tags('Settlement History')
+export class SettlementHistoryController extends Controller {
+  /**
+   * 정산 내역 조회 (기간별)
+   * @param userId - 사용자 ID (UUID 문자열)
+   * @param startDate - 조회 시작 날짜 (YYYY-MM-DD)
+   * @param endDate - 조회 종료 날짜 (YYYY-MM-DD)
+   * @returns 정산 내역 목록
+   */
+  @Get('{userId}')
+  @SuccessResponse('200', '정산 내역 조회 성공')
+  @Response(400, 'Bad Request')
+  @Response(404, 'User Not Found')
+  @Response(500, 'Internal Server Error')
+  public async getSettlementHistory(
+    @Path() userId: string,
+    @Query() startDate: string,
+    @Query() endDate: string,
+  ): Promise<TsoaSuccessResponse<SettlementHistoryResponseDto>> {
+    // UUID 문자열을 Buffer로 변환
+    const userIdBuffer = uuidToBuffer(userId);
+
+    // 날짜 문자열을 Date 객체로 변환
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+
+    // Service 호출
+    const history = await SettlementHistoryService.getSettlementHistory(
+      userIdBuffer,
+      start,
+      end,
+    );
+
+    // 성공 응답 반환
+    return new TsoaSuccessResponse(history);
+  }
+
+  /**
+   * 월별 정산 요약 조회
+   * @param userId - 사용자 ID (UUID 문자열)
+   * @param year - 조회 연도 (예: 2025)
+   * @returns 월별 정산 요약 목록
+   */
+  @Get('{userId}/monthly')
+  @SuccessResponse('200', '월별 정산 요약 조회 성공')
+  @Response(400, 'Bad Request')
+  @Response(404, 'User Not Found')
+  @Response(500, 'Internal Server Error')
+  public async getMonthlySettlementSummary(
+    @Path() userId: string,
+    @Query() year: number,
+  ): Promise<TsoaSuccessResponse<MonthlySettlementSummaryDto[]>> {
+    // UUID 문자열을 Buffer로 변환
+    const userIdBuffer = uuidToBuffer(userId);
+
+    // Service 호출
+    const summary = await SettlementHistoryService.getMonthlySettlementSummary(
+      userIdBuffer,
+      year,
+    );
+
+    // 성공 응답 반환
+    return new TsoaSuccessResponse(summary);
+  }
+}

--- a/src/repository/settlement_history_repository.ts
+++ b/src/repository/settlement_history_repository.ts
@@ -1,0 +1,143 @@
+import prisma from '../config/prisma';
+
+/**
+ * Settlement History Repository
+ * 정산 내역 데이터베이스 접근 계층
+ */
+class SettlementHistoryRepository {
+  /**
+   * 사용자의 정산 내역 조회 (기간별)
+   * @param userId - 사용자 ID
+   * @param startDate - 조회 시작 날짜
+   * @param endDate - 조회 종료 날짜
+   * @returns 정산 내역 목록
+   */
+  async findSettlementsByPeriod(
+    userId: Uint8Array,
+    startDate: Date,
+    endDate: Date,
+  ): Promise<
+    {
+      income_log_id: Uint8Array;
+      amount: number | null;
+      income_date: Date | null;
+      user_work_log: {
+        work_date: Date | null;
+        alba_posting: {
+          store: {
+            store_name: string | null;
+          };
+        };
+      };
+    }[]
+  > {
+    return await prisma.income_log.findMany({
+      where: {
+        user_id: userId as Uint8Array<ArrayBuffer>,
+        income_date: {
+          gte: startDate,
+          lte: endDate,
+        },
+      },
+      include: {
+        user_work_log: {
+          include: {
+            alba_posting: {
+              include: {
+                store: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: {
+        income_date: 'desc',
+      },
+    });
+  }
+
+  /**
+   * 사용자의 월별 정산 요약 조회
+   * @param userId - 사용자 ID
+   * @param year - 조회 연도
+   * @returns 월별 정산 요약
+   */
+  async getMonthlySettlementSummary(
+    userId: Uint8Array,
+    year: number,
+  ): Promise<
+    {
+      month: number;
+      totalAmount: number;
+      count: number;
+    }[]
+  > {
+    const startDate = new Date(year, 0, 1);
+    const endDate = new Date(year, 11, 31);
+
+    const result = await prisma.income_log.groupBy({
+      by: ['income_date'],
+      where: {
+        user_id: userId as Uint8Array<ArrayBuffer>,
+        income_date: {
+          gte: startDate,
+          lte: endDate,
+        },
+      },
+      _sum: {
+        amount: true,
+      },
+      _count: true,
+    });
+
+    // 월별로 그룹화
+    const monthlyData = new Map<number, { totalAmount: number; count: number }>();
+
+    for (const item of result) {
+      if (item.income_date) {
+        const month = item.income_date.getMonth() + 1;
+        const existing = monthlyData.get(month) || { totalAmount: 0, count: 0 };
+        monthlyData.set(month, {
+          totalAmount: existing.totalAmount + (item._sum.amount || 0),
+          count: existing.count + item._count,
+        });
+      }
+    }
+
+    return Array.from(monthlyData.entries()).map(([month, data]) => ({
+      month,
+      totalAmount: data.totalAmount,
+      count: data.count,
+    }));
+  }
+
+  /**
+   * 사용자의 총 정산 금액 조회 (기간별)
+   * @param userId - 사용자 ID
+   * @param startDate - 조회 시작 날짜
+   * @param endDate - 조회 종료 날짜
+   * @returns 총 정산 금액
+   */
+  async getTotalAmountByPeriod(
+    userId: Uint8Array,
+    startDate: Date,
+    endDate: Date,
+  ): Promise<number> {
+    const result = await prisma.income_log.aggregate({
+      where: {
+        user_id: userId as Uint8Array<ArrayBuffer>,
+        income_date: {
+          gte: startDate,
+          lte: endDate,
+        },
+      },
+      _sum: {
+        amount: true,
+      },
+    });
+
+    return result._sum.amount || 0;
+  }
+}
+
+export default new SettlementHistoryRepository();

--- a/src/service/settlement_history_service.ts
+++ b/src/service/settlement_history_service.ts
@@ -1,0 +1,83 @@
+import SettlementHistoryRepository from '../repository/settlement_history_repository';
+import {
+  SettlementHistoryResponseDto,
+  SettlementHistoryItemDto,
+  MonthlySettlementSummaryDto,
+} from '../DTO/settlement_history_dto';
+import { bufferToUuid } from '../util/uuid_util';
+import { formatDate } from '../util/date_util';
+
+/**
+ * Settlement History Service
+ * 정산 내역 관련 비즈니스 로직 처리
+ */
+class SettlementHistoryService {
+  /**
+   * 정산 내역 조회 (기간별)
+   * @param userId - 사용자 ID (Buffer 형식)
+   * @param startDate - 조회 시작 날짜
+   * @param endDate - 조회 종료 날짜
+   * @returns 정산 내역 응답
+   */
+  async getSettlementHistory(
+    userId: Uint8Array,
+    startDate: Date,
+    endDate: Date,
+  ): Promise<SettlementHistoryResponseDto> {
+    // 1. Repository에서 정산 내역 가져오기
+    const settlements = await SettlementHistoryRepository.findSettlementsByPeriod(
+      userId,
+      startDate,
+      endDate,
+    );
+
+    // 2. 총 정산 금액 계산
+    const totalAmount = await SettlementHistoryRepository.getTotalAmountByPeriod(
+      userId,
+      startDate,
+      endDate,
+    );
+
+    // 3. DTO 형식으로 변환
+    const settlementItems: SettlementHistoryItemDto[] = settlements.map((item) => ({
+      incomeLogId: bufferToUuid(item.income_log_id),
+      workDate: item.user_work_log.work_date ? formatDate(item.user_work_log.work_date) : '',
+      storeName: item.user_work_log.alba_posting.store.store_name || '',
+      amount: item.amount || 0,
+      incomeDate: item.income_date ? formatDate(item.income_date) : '',
+    }));
+
+    return {
+      settlements: settlementItems,
+      totalAmount,
+      periodStart: formatDate(startDate),
+      periodEnd: formatDate(endDate),
+    };
+  }
+
+  /**
+   * 월별 정산 요약 조회
+   * @param userId - 사용자 ID (Buffer 형식)
+   * @param year - 조회 연도
+   * @returns 월별 정산 요약 목록
+   */
+  async getMonthlySettlementSummary(
+    userId: Uint8Array,
+    year: number,
+  ): Promise<MonthlySettlementSummaryDto[]> {
+    // 1. Repository에서 월별 요약 가져오기
+    const monthlySummary = await SettlementHistoryRepository.getMonthlySettlementSummary(
+      userId,
+      year,
+    );
+
+    // 2. DTO 형식으로 변환 (YYYY-MM 포맷)
+    return monthlySummary.map((item) => ({
+      month: `${year}-${String(item.month).padStart(2, '0')}`,
+      totalAmount: item.totalAmount,
+      count: item.count,
+    }));
+  }
+}
+
+export default new SettlementHistoryService();

--- a/src/util/date_util.ts
+++ b/src/util/date_util.ts
@@ -1,0 +1,36 @@
+/**
+ * 날짜 유틸리티 함수
+ */
+
+/**
+ * Date를 "YYYY-MM-DD" 문자열로 변환
+ * @param date - 날짜
+ * @returns 포맷된 문자열
+ */
+export function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * 생년월일에서 나이 계산
+ * @param birthDate - 생년월일
+ * @returns 나이
+ */
+export function calculateAge(birthDate: Date | null): number {
+  if (!birthDate) return 0;
+
+  const today = new Date();
+  const birth = new Date(birthDate);
+  let age = today.getFullYear() - birth.getFullYear();
+  const monthDiff = today.getMonth() - birth.getMonth();
+
+  // 생일이 아직 안 지났으면 -1
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    age--;
+  }
+
+  return age;
+}

--- a/src/util/uuid_util.ts
+++ b/src/util/uuid_util.ts
@@ -1,0 +1,23 @@
+/**
+ * UUID 유틸리티 함수
+ */
+
+/**
+ * UUID 문자열을 Uint8Array(Buffer)로 변환
+ * @param uuid - UUID 문자열 (예: "550e8400-e29b-41d4-a716-446655440000")
+ * @returns Uint8Array
+ */
+export function uuidToBuffer(uuid: string): Uint8Array {
+  const hex = uuid.replace(/-/g, '');
+  return Buffer.from(hex, 'hex');
+}
+
+/**
+ * Buffer(Binary UUID)를 문자열 UUID로 변환
+ * @param buffer - Uint8Array 형식의 UUID
+ * @returns 문자열 UUID
+ */
+export function bufferToUuid(buffer: Uint8Array): string {
+  const hex = Buffer.from(buffer).toString('hex');
+  return `${hex.substring(0, 8)}-${hex.substring(8, 12)}-${hex.substring(12, 16)}-${hex.substring(16, 20)}-${hex.substring(20, 32)}`;
+}


### PR DESCRIPTION
## Summary
- 기간별 정산 내역 조회 API 구현 (`GET /api/settlement-history/{userId}`)
- 월별 정산 요약 조회 API 구현 (`GET /api/settlement-history/{userId}/monthly`)
- 공통 util 함수 분리 (uuid_util, date_util)

## API Endpoints

### 1. 정산 내역 조회 (기간별)
- **Endpoint**: `GET /api/settlement-history/{userId}?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD`
- **Response**: 정산 목록, 총 정산 금액, 조회 기간

### 2. 월별 정산 요약
- **Endpoint**: `GET /api/settlement-history/{userId}/monthly?year=2025`
- **Response**: 월별 정산 금액 및 건수

## Test plan
- [ ] 정산 내역 조회 API 테스트
- [ ] 월별 요약 조회 API 테스트
- [ ] Swagger 문서 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added settlement history lookup endpoint with date range filtering to retrieve income records and totals.
  * Added monthly settlement summary endpoint to view aggregated totals and counts per month for a specified year.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->