### PR TITLE
[FIX] region_id 타입 UUID → Int 변경

### DIFF
--- a/src/DTO/user_preferred_region_dto.ts
+++ b/src/DTO/user_preferred_region_dto.ts
@@ -6,7 +6,7 @@
  * 지역 정보 응답
  */
 export interface RegionDto {
-  regionId: string;
+  regionId: number;
   city: string;
   district: string;
 }
@@ -23,7 +23,7 @@ export interface UserPreferredRegionResponseDto {
  * 주요 활동 지역 추가 요청
  */
 export interface AddPreferredRegionRequestDto {
-  regionId: string;
+  regionId: number;
 }
 
 /**
@@ -31,7 +31,7 @@ export interface AddPreferredRegionRequestDto {
  */
 export interface AddPreferredRegionResponseDto {
   userId: string;
-  regionId: string;
+  regionId: number;
   city: string;
   district: string;
   createdAt: string;

--- a/src/controller/user_preferred_region_controller.ts
+++ b/src/controller/user_preferred_region_controller.ts
@@ -32,16 +32,6 @@ import { uuidToBuffer } from '../util/uuid_util';
 @Tags('User Preferred Region')
 export class UserPreferredRegionController extends Controller {
   /**
-   * UUID 형식 검증
-   * @param uuid UUID 문자열
-   */
-  private validateUuid(uuid: string): boolean {
-    const uuidRegex =
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    return uuidRegex.test(uuid);
-  }
-
-  /**
    * 주요 활동 지역 목록 조회 API
    * @param req Express Request (JWT에서 userId 추출)
    * @returns 주요 활동 지역 목록
@@ -83,18 +73,12 @@ export class UserPreferredRegionController extends Controller {
   ): Promise<TsoaSuccessResponse<AddPreferredRegionResponseDto>> {
     const userId = (req.user as unknown as { id: string }).id;
 
-    if (!this.validateUuid(requestBody.regionId)) {
-      this.setStatus(400);
-      throw new Error('유효하지 않은 지역 ID 형식입니다.');
-    }
-
     const userIdBuffer = uuidToBuffer(userId);
-    const regionIdBuffer = uuidToBuffer(requestBody.regionId);
 
     try {
       const result = await UserPreferredRegionService.addPreferredRegion(
         userIdBuffer,
-        regionIdBuffer,
+        requestBody.regionId,
       );
       this.setStatus(201);
       return new TsoaSuccessResponse(result);
@@ -115,7 +99,7 @@ export class UserPreferredRegionController extends Controller {
   /**
    * 주요 활동 지역 삭제 API
    * @param req Express Request (JWT에서 userId 추출)
-   * @param regionId 지역 ID (UUID 문자열)
+   * @param regionId 지역 ID (숫자)
    */
   @Delete('me/preferred-regions/{regionId}')
   @Security('jwt')
@@ -126,22 +110,16 @@ export class UserPreferredRegionController extends Controller {
   @Response(500, 'Internal Server Error')
   public async removePreferredRegion(
     @Request() req: ExpressRequest,
-    @Path() regionId: string,
+    @Path() regionId: number,
   ): Promise<void> {
     const userId = (req.user as unknown as { id: string }).id;
 
-    if (!this.validateUuid(regionId)) {
-      this.setStatus(400);
-      throw new Error('유효하지 않은 지역 ID 형식입니다.');
-    }
-
     const userIdBuffer = uuidToBuffer(userId);
-    const regionIdBuffer = uuidToBuffer(regionId);
 
     try {
       await UserPreferredRegionService.removePreferredRegion(
         userIdBuffer,
-        regionIdBuffer,
+        regionId,
       );
       this.setStatus(204);
     } catch (error) {

--- a/src/repository/user_preferred_region_repository.ts
+++ b/src/repository/user_preferred_region_repository.ts
@@ -37,13 +37,13 @@ class UserPreferredRegionRepository {
   /**
    * 주요 활동 지역 추가
    * @param userId 사용자 ID (Buffer)
-   * @param regionId 지역 ID (Buffer)
+   * @param regionId 지역 ID (number)
    */
-  async create(userId: Uint8Array, regionId: Uint8Array) {
+  async create(userId: Uint8Array, regionId: number) {
     return await prisma.user_preferred_region.create({
       data: {
         user_id: userId as Uint8Array<ArrayBuffer>,
-        region_id: regionId as Uint8Array<ArrayBuffer>,
+        region_id: regionId,
       },
       include: {
         region: true,
@@ -54,14 +54,14 @@ class UserPreferredRegionRepository {
   /**
    * 주요 활동 지역 삭제
    * @param userId 사용자 ID (Buffer)
-   * @param regionId 지역 ID (Buffer)
+   * @param regionId 지역 ID (number)
    */
-  async delete(userId: Uint8Array, regionId: Uint8Array) {
+  async delete(userId: Uint8Array, regionId: number) {
     return await prisma.user_preferred_region.delete({
       where: {
-        user_id_region_id: {
+        region_id_user_id: {
           user_id: userId as Uint8Array<ArrayBuffer>,
-          region_id: regionId as Uint8Array<ArrayBuffer>,
+          region_id: regionId,
         },
       },
     });
@@ -70,14 +70,14 @@ class UserPreferredRegionRepository {
   /**
    * 특정 지역이 이미 등록되어 있는지 확인
    * @param userId 사용자 ID (Buffer)
-   * @param regionId 지역 ID (Buffer)
+   * @param regionId 지역 ID (number)
    */
-  async exists(userId: Uint8Array, regionId: Uint8Array): Promise<boolean> {
+  async exists(userId: Uint8Array, regionId: number): Promise<boolean> {
     const result = await prisma.user_preferred_region.findUnique({
       where: {
-        user_id_region_id: {
+        region_id_user_id: {
           user_id: userId as Uint8Array<ArrayBuffer>,
-          region_id: regionId as Uint8Array<ArrayBuffer>,
+          region_id: regionId,
         },
       },
     });
@@ -86,12 +86,12 @@ class UserPreferredRegionRepository {
 
   /**
    * 지역 정보 조회 (ID로)
-   * @param regionId 지역 ID (Buffer)
+   * @param regionId 지역 ID (number)
    */
-  async findRegionById(regionId: Uint8Array) {
+  async findRegionById(regionId: number) {
     return await prisma.region.findUnique({
       where: {
-        region_id: regionId as Uint8Array<ArrayBuffer>,
+        region_id: regionId,
       },
     });
   }

--- a/src/service/user_preferred_region_service.ts
+++ b/src/service/user_preferred_region_service.ts
@@ -23,7 +23,7 @@ class UserPreferredRegionService {
     const regions = await UserPreferredRegionRepository.findByUserId(userId);
 
     const regionDtos: RegionDto[] = regions.map((item) => ({
-      regionId: bufferToUuid(item.region.region_id),
+      regionId: item.region.region_id,
       city: item.region.city || '',
       district: item.region.district || '',
     }));
@@ -37,11 +37,11 @@ class UserPreferredRegionService {
   /**
    * 주요 활동 지역 추가
    * @param userId 사용자 ID (Buffer)
-   * @param regionId 지역 ID (Buffer)
+   * @param regionId 지역 ID (number)
    */
   async addPreferredRegion(
     userId: Uint8Array,
-    regionId: Uint8Array,
+    regionId: number,
   ): Promise<AddPreferredRegionResponseDto> {
     // 1. 지역이 존재하는지 확인
     const region = await UserPreferredRegionRepository.findRegionById(regionId);
@@ -66,7 +66,7 @@ class UserPreferredRegionService {
 
     return {
       userId: bufferToUuid(created.user_id),
-      regionId: bufferToUuid(created.region_id),
+      regionId: created.region_id,
       city: created.region.city || '',
       district: created.region.district || '',
       createdAt: created.created_at.toISOString(),
@@ -76,11 +76,11 @@ class UserPreferredRegionService {
   /**
    * 주요 활동 지역 삭제
    * @param userId 사용자 ID (Buffer)
-   * @param regionId 지역 ID (Buffer)
+   * @param regionId 지역 ID (number)
    */
   async removePreferredRegion(
     userId: Uint8Array,
-    regionId: Uint8Array,
+    regionId: number,
   ): Promise<void> {
     // 등록된 지역인지 확인
     const exists = await UserPreferredRegionRepository.exists(userId, regionId);
@@ -106,7 +106,7 @@ class UserPreferredRegionService {
     );
 
     const regionDtos: RegionDto[] = regions.map((item) => ({
-      regionId: bufferToUuid(item.region_id),
+      regionId: item.region_id,
       city: item.city || '',
       district: item.district || '',
     }));


### PR DESCRIPTION
## Summary
- 최신 DB 스키마 변경에 맞춰 `user_preferred_region` 관련 코드에서 `region_id` 타입을 `UUID(Bytes)` → `Int`로 수정
- DTO, Controller, Service, Repository 4개 파일 수정

## Changes
- **DTO**: `regionId` 타입 `string` → `number`
- **Controller**: UUID 검증 로직(`validateUuid`) 제거, `regionId`를 `number`로 처리
- **Service**: `regionId` 파라미터 `Uint8Array` → `number`, `bufferToUuid()` 변환 제거
- **Repository**: `regionId` 파라미터 및 Prisma 쿼리 `Int` 타입으로 변경, composite key 이름 업데이트

## Test plan
- [ ] `prisma generate` 후 타입 에러 없는지 확인
- [ ] `GET /api/regions` 지역 검색 정상 동작 확인
- [ ] `POST /api/users/me/preferred-regions` 지역 추가 정상 동작 확인
- [ ] `DELETE /api/users/me/preferred-regions/{regionId}` 지역 삭제 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Region IDs now use numeric format instead of UUID strings across all region-related API operations.
  * Updated request and response payloads for adding and managing preferred regions to accept and return numeric identifiers.
  * Clients must update implementations to work with the new numeric region ID format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->