### PR TITLE
[REFACTOR] userId Path 파라미터를 JWT 인증 방식으로 변경

### DIFF
--- a/src/controller/profile_controller.ts
+++ b/src/controller/profile_controller.ts
@@ -1,4 +1,16 @@
-import { Controller, Get, Put, Route, Tags, Path, Body, SuccessResponse, Response } from 'tsoa';
+import {
+  Controller,
+  Get,
+  Put,
+  Route,
+  Tags,
+  Body,
+  SuccessResponse,
+  Response,
+  Security,
+  Request,
+} from 'tsoa';
+import { Request as ExpressRequest } from 'express';
 import ProfileService from '../service/profile_service';
 import { ProfileResponseDto, UpdateProfileRequestDto } from '../DTO/profile_dto';
 import { TsoaSuccessResponse } from '../config/response_interface';
@@ -13,46 +25,44 @@ import { uuidToBuffer } from '../util/uuid_util';
 export class ProfileController extends Controller {
   /**
    * 프로필 조회
-   * @param userId - 사용자 ID (UUID 문자열)
+   * @param req Express Request (JWT에서 userId 추출)
    * @returns 프로필 정보
    */
-  @Get('{userId}')
+  @Get('me')
+  @Security('jwt')
   @SuccessResponse('200', '프로필 조회 성공')
+  @Response(401, 'Unauthorized')
   @Response(404, 'User Not Found')
   @Response(500, 'Internal Server Error')
-  public async getProfile(@Path() userId: string): Promise<TsoaSuccessResponse<ProfileResponseDto>> {
-    // UUID 문자열을 Buffer로 변환
+  public async getProfile(
+    @Request() req: ExpressRequest,
+  ): Promise<TsoaSuccessResponse<ProfileResponseDto>> {
+    const userId = (req.user as unknown as { id: string }).id;
     const userIdBuffer = uuidToBuffer(userId);
-
-    // Service 호출
     const profile = await ProfileService.getProfile(userIdBuffer);
-
-    // 성공 응답 반환
     return new TsoaSuccessResponse(profile);
   }
 
   /**
    * 프로필 수정
-   * @param userId - 사용자 ID (UUID 문자열)
+   * @param req Express Request (JWT에서 userId 추출)
    * @param requestBody - 수정할 프로필 데이터
    * @returns 수정된 프로필 정보
    */
-  @Put('{userId}')
+  @Put('me')
+  @Security('jwt')
   @SuccessResponse('200', '프로필 수정 성공')
   @Response(400, 'Bad Request')
+  @Response(401, 'Unauthorized')
   @Response(404, 'User Not Found')
   @Response(500, 'Internal Server Error')
   public async updateProfile(
-    @Path() userId: string,
+    @Request() req: ExpressRequest,
     @Body() requestBody: UpdateProfileRequestDto,
   ): Promise<TsoaSuccessResponse<ProfileResponseDto>> {
-    // UUID 문자열을 Buffer로 변환
+    const userId = (req.user as unknown as { id: string }).id;
     const userIdBuffer = uuidToBuffer(userId);
-
-    // Service 호출
     const profile = await ProfileService.updateProfile(userIdBuffer, requestBody);
-
-    // 성공 응답 반환
     return new TsoaSuccessResponse(profile);
   }
 }

--- a/src/controller/review_controller.ts
+++ b/src/controller/review_controller.ts
@@ -1,7 +1,27 @@
-import { Controller, Get, Put, Delete, Route, Tags, Path, Body, Query, SuccessResponse, Response } from 'tsoa';
+import {
+  Controller,
+  Get,
+  Put,
+  Delete,
+  Route,
+  Tags,
+  Path,
+  Body,
+  Query,
+  SuccessResponse,
+  Response,
+  Security,
+  Request,
+} from 'tsoa';
+import { Request as ExpressRequest } from 'express';
 import ReviewService from '../service/review_service';
-import { ReviewResponseDto, ReviewListResponseDto, UpdateReviewRequestDto } from '../DTO/review_dto';
+import {
+  ReviewResponseDto,
+  ReviewListResponseDto,
+  UpdateReviewRequestDto,
+} from '../DTO/review_dto';
 import { TsoaSuccessResponse } from '../config/response_interface';
+import { uuidToBuffer } from '../util/uuid_util';
 
 /**
  * Review Controller
@@ -12,19 +32,22 @@ import { TsoaSuccessResponse } from '../config/response_interface';
 export class ReviewController extends Controller {
   /**
    * 내 리뷰 목록 조회
-   * @param userId - 사용자 ID (UUID 문자열)
+   * @param req Express Request (JWT에서 userId 추출)
    * @param sort - 정렬 방식 ('latest' = 최신순, 'oldest' = 오래된순)
    * @returns 리뷰 목록
    */
-  @Get('{userId}/reviews')
+  @Get('me/reviews')
+  @Security('jwt')
   @SuccessResponse('200', '리뷰 목록 조회 성공')
+  @Response(401, 'Unauthorized')
   @Response(404, 'User Not Found')
   @Response(500, 'Internal Server Error')
   public async getMyReviews(
-    @Path() userId: string,
+    @Request() req: ExpressRequest,
     @Query() sort: 'latest' | 'oldest' = 'latest',
   ): Promise<TsoaSuccessResponse<ReviewListResponseDto>> {
-    const userIdBuffer = this.uuidToBuffer(userId);
+    const userId = (req.user as unknown as { id: string }).id;
+    const userIdBuffer = uuidToBuffer(userId);
     const orderBy = sort === 'latest' ? 'desc' : 'asc';
 
     const reviews = await ReviewService.getReviewsByUserId(userIdBuffer, orderBy);
@@ -34,24 +57,27 @@ export class ReviewController extends Controller {
 
   /**
    * 리뷰 수정
-   * @param userId - 사용자 ID (UUID 문자열)
+   * @param req Express Request (JWT에서 userId 추출)
    * @param reviewId - 리뷰 ID (UUID 문자열)
    * @param requestBody - 수정할 리뷰 데이터
    * @returns 수정된 리뷰 정보
    */
-  @Put('{userId}/reviews/{reviewId}')
+  @Put('me/reviews/{reviewId}')
+  @Security('jwt')
   @SuccessResponse('200', '리뷰 수정 성공')
   @Response(400, 'Bad Request')
+  @Response(401, 'Unauthorized')
   @Response(403, 'Forbidden - 본인의 리뷰만 수정 가능')
   @Response(404, 'Review Not Found')
   @Response(500, 'Internal Server Error')
   public async updateReview(
-    @Path() userId: string,
+    @Request() req: ExpressRequest,
     @Path() reviewId: string,
     @Body() requestBody: UpdateReviewRequestDto,
   ): Promise<TsoaSuccessResponse<ReviewResponseDto>> {
-    const userIdBuffer = this.uuidToBuffer(userId);
-    const reviewIdBuffer = this.uuidToBuffer(reviewId);
+    const userId = (req.user as unknown as { id: string }).id;
+    const userIdBuffer = uuidToBuffer(userId);
+    const reviewIdBuffer = uuidToBuffer(reviewId);
 
     const review = await ReviewService.updateReview(reviewIdBuffer, userIdBuffer, requestBody);
 
@@ -60,33 +86,26 @@ export class ReviewController extends Controller {
 
   /**
    * 리뷰 삭제
-   * @param userId - 사용자 ID (UUID 문자열)
+   * @param req Express Request (JWT에서 userId 추출)
    * @param reviewId - 리뷰 ID (UUID 문자열)
    */
-  @Delete('{userId}/reviews/{reviewId}')
+  @Delete('me/reviews/{reviewId}')
+  @Security('jwt')
   @SuccessResponse('200', '리뷰 삭제 성공')
+  @Response(401, 'Unauthorized')
   @Response(403, 'Forbidden - 본인의 리뷰만 삭제 가능')
   @Response(404, 'Review Not Found')
   @Response(500, 'Internal Server Error')
   public async deleteReview(
-    @Path() userId: string,
+    @Request() req: ExpressRequest,
     @Path() reviewId: string,
   ): Promise<TsoaSuccessResponse<{ message: string }>> {
-    const userIdBuffer = this.uuidToBuffer(userId);
-    const reviewIdBuffer = this.uuidToBuffer(reviewId);
+    const userId = (req.user as unknown as { id: string }).id;
+    const userIdBuffer = uuidToBuffer(userId);
+    const reviewIdBuffer = uuidToBuffer(reviewId);
 
     await ReviewService.deleteReview(reviewIdBuffer, userIdBuffer);
 
     return new TsoaSuccessResponse({ message: '리뷰가 삭제되었습니다.' });
-  }
-
-  /**
-   * UUID 문자열을 Uint8Array로 변환
-   * @param uuid - UUID 문자열 (예: "550e8400-e29b-41d4-a716-446655440000")
-   * @returns Uint8Array
-   */
-  private uuidToBuffer(uuid: string): Uint8Array {
-    const hex = uuid.replace(/-/g, '');
-    return Buffer.from(hex, 'hex');
   }
 }

--- a/src/controller/settlement_history_controller.ts
+++ b/src/controller/settlement_history_controller.ts
@@ -1,4 +1,15 @@
-import { Controller, Get, Route, Tags, Path, Query, SuccessResponse, Response } from 'tsoa';
+import {
+  Controller,
+  Get,
+  Route,
+  Tags,
+  Query,
+  SuccessResponse,
+  Response,
+  Security,
+  Request,
+} from 'tsoa';
+import { Request as ExpressRequest } from 'express';
 import SettlementHistoryService from '../service/settlement_history_service';
 import { SettlementHistoryResponseDto } from '../DTO/settlement_history_dto';
 import { TsoaSuccessResponse } from '../config/response_interface';
@@ -13,34 +24,23 @@ import { uuidToBuffer } from '../util/uuid_util';
 export class SettlementHistoryController extends Controller {
   /**
    * 정산 내역 조회 API
-   * @param userId 사용자 ID (UUID 문자열)
+   * @param req Express Request (JWT에서 userId 추출)
    * @param status 정산 상태 필터 (all: 전체, waiting: 정산 대기, paid: 정산 완료, unpaid: 미정산)
    * @returns 정산 내역 목록
    */
-  @Get('{userId}')
+  @Get('me')
+  @Security('jwt')
   @SuccessResponse('200', '정산 내역 조회 성공')
-  @Response(400, 'Bad Request')
-  @Response(404, 'User Not Found')
+  @Response(401, 'Unauthorized')
   @Response(500, 'Internal Server Error')
   public async getSettlementHistory(
-    @Path() userId: string,
+    @Request() req: ExpressRequest,
     @Query() status: 'all' | 'waiting' | 'paid' | 'unpaid' = 'all',
   ): Promise<TsoaSuccessResponse<SettlementHistoryResponseDto>> {
-    // UUID 형식 검증
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(userId)) {
-      this.setStatus(400);
-      throw new Error('유효하지 않은 사용자 ID 형식입니다.');
-    }
-
-    // UUID 문자열을 Buffer로 변환
+    const userId = (req.user as unknown as { id: string }).id;
     const userIdBuffer = uuidToBuffer(userId);
 
-    // Service 호출
-    const history = await SettlementHistoryService.getSettlementHistory(
-      userIdBuffer,
-      status,
-    );
+    const history = await SettlementHistoryService.getSettlementHistory(userIdBuffer, status);
 
     return new TsoaSuccessResponse(history);
   }


### PR DESCRIPTION
## Summary
- profile, review, settlement, settlement_history 컨트롤러에서 URL Path로 전달하던 userId를 JWT 토큰 기반 인증으로 변경
- 기존: `GET /api/profile/{userId}` → 변경: `GET /api/profile/me` (JWT 필수)

## Changes
- **profile_controller**: `GET/PUT api/profile/{userId}` → `GET/PUT api/profile/me`
- **review_controller**: `GET/PUT/DELETE api/users/{userId}/reviews` → `api/users/me/reviews`
- **settlement_controller**: `GET/PUT api/users/{userId}/settlement` → `api/users/me/settlement`
- **settlement_history_controller**: `GET api/settlement-history/{userId}` → `GET api/settlement-history/me`
- 모든 엔드포인트에 `@Security('jwt')` 추가
- private `uuidToBuffer` 메서드 제거, 공용 유틸(`src/util/uuid_util.ts`) 사용으로 통일

## Test plan
- [ ] JWT 토큰으로 `GET /api/profile/me` 호출 시 본인 프로필 반환 확인
- [ ] JWT 토큰으로 `GET /api/users/me/reviews` 호출 시 본인 리뷰 목록 반환 확인
- [ ] JWT 토큰으로 `GET /api/users/me/settlement` 호출 시 본인 계좌 정보 반환 확인
- [ ] JWT 토큰으로 `GET /api/settlement-history/me` 호출 시 본인 정산 내역 반환 확인
- [ ] JWT 없이 호출 시 401 Unauthorized 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Enforced JWT authentication across profile, review, settlement, and settlement history endpoints.
  * Unauthenticated requests receive 401 Unauthorized responses.

* **API Updates**
  * User-specific endpoints now use authenticated "me" routes instead of path-based user IDs.
  * User identity is derived from JWT authentication instead of URL parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->